### PR TITLE
add support to upgrade dependencies in hatch envs

### DIFF
--- a/src/uppd/uppd.py
+++ b/src/uppd/uppd.py
@@ -245,6 +245,14 @@ async def main(
         *project.get("optional-dependencies", {}).values(),
     ]
 
+    # hatch allows for several envs that can all have dependencies
+    # they are all stores in [tool.hatch.envs.<ENV_NAME>] sections
+    # see https://hatch.pypa.io/1.9/config/environment/overview/ for more information
+    for env in data.get("tool", {}).get("hatch", {}).get("envs", {}).values():
+        for key in ("dependencies", "extra-dependencies"):
+            if key in env:
+                deps.append(env[key])
+
     try:
         async with ClientSession(index_url) as session:
             await gather(


### PR DESCRIPTION
Hello,

This PR adds support for hatch envs which can also contains dependencies.

Hatch is, yet another, project manager for python and this one allows you to
create several different envs (for example for linting, testing or whatever)
which can all have dependencies sections exactly like the `[project]` section.

They looks like that:

```toml
[tool.hatch.envs.<ENV_NAME>]
dependencies = [
  "...",
]
```

And they can also have an `extra-dependencies` key which looks like that:

```toml
[tool.hatch.envs.<ENV_NAME>]
extra-dependencies = [
  "...",
]
```

This PR simply adds the `dependencies` and `extra-dependencies` sections of
those envs, if they exists, in the list of sections on which to upgrade
dependencies.

I'm available if you have any comments on the PR.

Kind regards and thx for this project <3
